### PR TITLE
Add WP Migrate DB Pro check and filter for other incompatibilities.

### DIFF
--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -113,6 +113,15 @@ class WDS_Required_Plugins {
 	 */
 	public function incompatible() {
 
+		// Our tests.
+		$this->incompatibilities = array(
+
+			/*
+			 * WP Migrate DB Pro is performing an AJAX migration.
+			 */
+			(boolean) $this->is_wpmdb(),
+		);
+
 		/**
 		 * Add or filter your incompatibility tests here.
 		 *
@@ -124,13 +133,12 @@ class WDS_Required_Plugins {
 		 * @since 1.0.0
 		 * @param array $incom A list of tests that determine incompatibilities.
 		 */
-		$this->incompatibilities = apply_filters( 'wds_required_plugins_incompatibilities', array(
+		$filter = apply_filters( 'wds_required_plugins_incompatibilities', $this->incompatibilities );
+		if ( is_array( $filter ) ) {
 
-			/*
-			 * WP Migrate DB Pro is performing an AJAX migration.
-			 */
-			(boolean) $this->is_wpmdb(),
-		) );
+			// The filter might have added more tests, use those.
+			$this->incompatibilities = $filter;
+		}
 
 		// If the array has any incompatibility, we are incompatible.
 		return in_array( true, $this->incompatibilities, true );

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -25,6 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @package WordPress
  *
  * @subpackage Project
+ * @since      Unknown
  */
 class WDS_Required_Plugins {
 
@@ -32,6 +33,7 @@ class WDS_Required_Plugins {
 	 * Instance of this class.
 	 *
 	 * @var WDS_Required_Plugins object
+	 * @since Unknown
 	 */
 	public static $instance = null;
 
@@ -39,6 +41,7 @@ class WDS_Required_Plugins {
 	 * Whether text-domain has been registered.
 	 *
 	 * @var boolean
+	 * @since  Unknown
 	 */
 	private static $l10n_done = false;
 
@@ -46,6 +49,7 @@ class WDS_Required_Plugins {
 	 * Text/markup for required text.
 	 *
 	 * @var string
+	 * @since  Unknown
 	 */
 	private $required_text = '';
 
@@ -89,6 +93,7 @@ class WDS_Required_Plugins {
 	 * Activate required plugins if they are not.
 	 *
 	 * @since 0.1.1
+	 * @return void Early bails when we don't need to activate it.
 	 */
 	public function activate_if_not() {
 
@@ -163,7 +168,7 @@ class WDS_Required_Plugins {
 		// If auto-activation failed, and there is an error, log it.
 		if ( apply_filters( 'wds_required_plugin_log_if_not_found', true, $plugin, $result, $network ) ) {
 
-			// Set default log text.
+			// translators: %1 and %2 are explained below. Set default log text.
 			$default_log_text = __( 'Required Plugin auto-activation failed for: %1$s, with message: %2$s', 'wds-required-plugins' );
 
 			// Filter the logging message format/text.
@@ -172,7 +177,7 @@ class WDS_Required_Plugins {
 			// Get our error message.
 			$error_message = method_exists( $result, 'get_error_message' ) ? $result->get_error_message() : '';
 
-			// Trigger our error, with all our log messages.
+			// Trigger our error, with all our log messages. @codingStandardsIgnoreLine: trigger_error okay here.
 			trigger_error( sprintf( esc_attr( $log_msg_format ), esc_attr( $plugin ), esc_attr( $error_message ) ) );
 		}
 
@@ -183,8 +188,6 @@ class WDS_Required_Plugins {
 	 * The required plugin label text.
 	 *
 	 * @since  0.1.0
-	 *
-	 * @return  void
 	 */
 	public function required_text_markup() {
 		$this->required_text = apply_filters( 'wds_required_plugins_text', sprintf( '<span style="color: #888">%s</span>', __( 'WDS Required Plugin', 'wds-required-plugins' ) ) );
@@ -223,7 +226,6 @@ class WDS_Required_Plugins {
 	 * @since   0.1.5
 	 *
 	 * @param   array $plugins Array of plugins.
-	 *
 	 * @return  array          Array of plugins.
 	 */
 	public function maybe_remove_plugins_from_list( $plugins ) {
@@ -321,4 +323,5 @@ class WDS_Required_Plugins {
 	}
 }
 
+// Init.
 WDS_Required_Plugins::init();

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -54,6 +54,16 @@ class WDS_Required_Plugins {
 	private $required_text = '';
 
 	/**
+	 * Logged incompatibilities.
+	 *
+	 * @author Aubrey Portwood
+	 * @since  1.0.0
+	 *
+	 * @var array
+	 */
+	public $incompatibilities = array();
+
+	/**
 	 * Creates or returns an instance of this class.
 	 *
 	 * @since  0.1.0
@@ -114,16 +124,16 @@ class WDS_Required_Plugins {
 		 * @since 1.0.0
 		 * @param array $incom A list of tests that determine incompatibilities.
 		 */
-		$incompatibilities = apply_filters( 'wds_required_plugins_incompatibilities', array(
+		$this->incompatibilities = apply_filters( 'wds_required_plugins_incompatibilities', array(
 
 			/*
 			 * WP Migrate DB Pro is performing an AJAX migration.
 			 */
-			(boolean) wp_doing_ajax() && $this->is_wpmdb(),
+			(boolean) $this->is_wpmdb(),
 		) );
 
 		// If the array has any incompatibility, we are incompatible.
-		return in_array( true, $incompatibilities, true );
+		return in_array( true, $this->incompatibilities, true );
 	}
 
 	/**
@@ -137,7 +147,7 @@ class WDS_Required_Plugins {
 	public function is_wpmdb() {
 
 		// @codingStandardsIgnoreLine: Nonce validation not necessary here.
-		return strpos( isset( $_POST['action'] ) ? filter_var( $_POST['action'], FILTER_SANITIZE_STRING ) : '', 'wpmdb' );
+		return stristr( isset( $_POST['action'] ) && is_string( $_POST['action'] ) ? $_POST['action'] : '', 'wpmdb_' );
 	}
 
 	/**

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -1,17 +1,17 @@
 <?php // @codingStandardsIgnoreLine: Filename okay here.
 /**
  * Plugin Name: WDS Required Plugins
- * Plugin URI: http://webdevstudios.com
+ * Plugin URI:  http://webdevstudios.com
  * Description: Forcefully require specific plugins to be activated.
- * Author: WebDevStudios
- * Author URI: http://webdevstudios.com
- * Version: 0.1.5
- * Domain: wds-required-plugins
- * License: GPLv2
- * Path: languages
+ * Author:      WebDevStudios
+ * Author URI:  http://webdevstudios.com
+ * Version:     1.0.0
+ * Domain:      wds-required-plugins
+ * License:     GPLv2
+ * Path:        languages
  *
- * @package WDS_Required_Plugins
- * @since   0.1.4
+ * @package     WDS_Required_Plugins
+ * @since       0.1.4
  */
 
 // Exit if accessed directly.

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -1,4 +1,4 @@
-<?php
+<?php // @codingStandardsIgnoreLine: Filename okay here.
 /**
  * Plugin Name: WDS Required Plugins
  * Plugin URI: http://webdevstudios.com

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -11,6 +11,7 @@
  * Path: languages
  *
  * @package WDS_Required_Plugins
+ * @since   0.1.4
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
Though, in #11, and in v0.1.5, there isn't any compatibility issues with Migrate DB Pro, this will at least disable it during any future WP Migrate DB Pro calls, which I think is still a good thing to do. Also, this adds a filter that will allow anyone to add other incompatibility tests to WDS-Required-Plugins when (and if) any other incompatibility is found.

This also cleans up the code to get with modern WDSCS and we can bring the plugin to 1.0.

Resolves #11 