### PR TITLE
Ticket/15 required plugin header

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ ____________________
 
 # Changelog
 
+## 1.2.0 
+
+- Added ability to add `Required: true` to plugin header to make plugin required vs. adding to filtered list <sup>[#20](https://github.com/WebDevStudios/WDS-Required-Plugins/pull/20/files)</sup>
+
 ## 1.1.0
 
 - You can have the project throw an `Exception` if there is an activation problem

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -517,6 +517,8 @@ class WDS_Required_Plugins {
 			return array();
 		}
 
+		$required_plugins = array_merge( $required_plugins, $this->get_header_required_plugins() );
+
 		return $required_plugins;
 	}
 
@@ -639,6 +641,62 @@ class WDS_Required_Plugins {
 
 		$extra_headers[] = $required_header;
 		return $extra_headers;
+	}
+
+	/**
+	 * Return a list of plugins with the required header set.
+	 *
+	 * @since NEXT
+	 * @author Zach Owen
+	 *
+	 * @return array
+	 */
+    public function get_header_required_plugins() {
+		$all_plugins = apply_filters( 'all_plugins', get_plugins() );
+
+		if ( empty( $all_plugins ) ) {
+			return;
+		}
+
+		$required_header = $this->get_required_header();
+		$plugins         = [];
+
+		foreach ( $all_plugins as $file => $headers ) {
+			if ( empty( $headers[ $required_header ] ) ) {
+				continue;
+			}
+
+			$plugins[] = $file;
+		}
+
+		return $plugins;
+	}
+
+	/**
+	 * Get the key to use for the required plugin header identifier.
+	 *
+	 * @author Zach Owen
+	 * @since NEXT
+	 *
+	 * @return string
+	 */
+	private function get_required_header() {
+		/**
+		 * Filter the text used as the identifier for the plugin being
+		 * required.
+		 *
+		 * @author Zach Owen
+		 * @since NEXT
+		 *
+		 * @param string $header The string to use as the identifier.
+		 */
+		$header = apply_filters( 'wds_required_plugin_header', 'Required' );
+
+		if ( ! is_string( $header ) || empty( $header ) ) {
+			return 'Required';
+		}
+
+		return $header;
 	}
 }
 

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -108,22 +108,24 @@ class WDS_Required_Plugins {
 	private function __construct() {
 
 		// Only if we are not incompatible with something.
-		if ( ! $this->incompatible() ) {
-
-			// Attempt activation + load text domain in the admin.
-			add_filter( 'admin_init', array( $this, 'activate_if_not' ) );
-			add_filter( 'admin_init', array( $this, 'required_text_markup' ) );
-
-			// Filter plugin links to remove deactivate option.
-			add_filter( 'plugin_action_links', array( $this, 'filter_plugin_links' ), 10, 2 );
-			add_filter( 'network_admin_plugin_action_links', array( $this, 'filter_plugin_links' ), 10, 2 );
-
-			// Remove plugins from the plugins.
-			add_filter( 'all_plugins', array( $this, 'maybe_remove_plugins_from_list' ) );
-
-			// Load text domain.
-			add_action( 'plugins_loaded', array( $this, 'l10n' ) );
+		if ( $this->incompatible() ) {
+			return;
 		}
+
+		// Attempt activation + load text domain in the admin.
+		add_filter( 'admin_init', array( $this, 'activate_if_not' ) );
+		add_filter( 'admin_init', array( $this, 'required_text_markup' ) );
+		add_filter( 'extra_plugin_headers', array( $this, 'add_required_plugin_header' ) );
+
+		// Filter plugin links to remove deactivate option.
+		add_filter( 'plugin_action_links', array( $this, 'filter_plugin_links' ), 10, 2 );
+		add_filter( 'network_admin_plugin_action_links', array( $this, 'filter_plugin_links' ), 10, 2 );
+
+		// Remove plugins from the plugins.
+		add_filter( 'all_plugins', array( $this, 'maybe_remove_plugins_from_list' ) );
+
+		// Load text domain.
+		add_action( 'plugins_loaded', array( $this, 'l10n' ) );
 	}
 
 	/**
@@ -617,6 +619,26 @@ class WDS_Required_Plugins {
 		$mofile = dirname( __FILE__ ) . '/languages/wds-required-plugins-' . $locale . '.mo';
 		load_textdomain( 'wds-required-plugins', $mofile );
 		self::$l10n_done = true;
+	}
+
+	/**
+	 * Adds a header field for required plugins when WordPress reads plugin data.
+	 *
+	 * @since NEXT
+	 * @author Zach Owen
+	 *
+	 * @param array $extra_headers Extra headers filtered in WP core.
+	 * @return array
+	 */
+	public function add_required_plugin_header( $extra_headers ) {
+		$required_header = $this->get_required_header();
+
+		if ( in_array( $required_header, $extra_headers, true ) ) {
+			return $extra_headers;
+		}
+
+		$extra_headers[] = $required_header;
+		return $extra_headers;
 	}
 }
 

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -626,7 +626,7 @@ class WDS_Required_Plugins {
 	/**
 	 * Adds a header field for required plugins when WordPress reads plugin data.
 	 *
-	 * @since NEXT
+	 * @since 1.2.0
 	 * @author Zach Owen
 	 *
 	 * @param array $extra_headers Extra headers filtered in WP core.
@@ -646,7 +646,7 @@ class WDS_Required_Plugins {
 	/**
 	 * Return a list of plugins with the required header set.
 	 *
-	 * @since NEXT
+	 * @since 1.2.0
 	 * @author Zach Owen
 	 *
 	 * @return array
@@ -661,8 +661,25 @@ class WDS_Required_Plugins {
 		$required_header = $this->get_required_header();
 		$plugins         = [];
 
+		/**
+		 * Filter the value for the header that would indicate the plugin as required.
+		 *
+		 * @author Aubrey Portwood <aubrey@webdevstudios.com>
+		 * @since  1.2.0
+		 *
+		 * @var array
+		 */
+		$values = apply_filters( 'wds_required_plugins_required_header_values', [
+			'true',
+			'yes',
+			'1',
+			'on',
+			'required',
+			'require',
+		] );
+
 		foreach ( $all_plugins as $file => $headers ) {
-			if ( empty( $headers[ $required_header ] ) ) {
+			if ( ! in_array( $headers[ $required_header ], $values, true ) ) {
 				continue;
 			}
 
@@ -676,24 +693,26 @@ class WDS_Required_Plugins {
 	 * Get the key to use for the required plugin header identifier.
 	 *
 	 * @author Zach Owen
-	 * @since NEXT
+	 * @since 1.2.0
 	 *
 	 * @return string
 	 */
 	private function get_required_header() {
+		$header_text = 'Required';
+
 		/**
 		 * Filter the text used as the identifier for the plugin being
 		 * required.
 		 *
 		 * @author Zach Owen
-		 * @since NEXT
+		 * @since 1.2.0
 		 *
 		 * @param string $header The string to use as the identifier.
 		 */
-		$header = apply_filters( 'wds_required_plugin_header', 'Required' );
+		$header = apply_filters( 'wds_required_plugin_header', $header_text );
 
 		if ( ! is_string( $header ) || empty( $header ) ) {
-			return 'Required';
+			return $header_text;
 		}
 
 		return $header;

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -651,7 +651,7 @@ class WDS_Required_Plugins {
 	 *
 	 * @return array
 	 */
-    public function get_header_required_plugins() {
+	public function get_header_required_plugins() {
 		$all_plugins = apply_filters( 'all_plugins', get_plugins() );
 
 		if ( empty( $all_plugins ) ) {


### PR DESCRIPTION
This address #15 

- Plugins with `Required: true` or similar (non-empty value) will be automatically added to the list of required plugins.
- Needs to be tested at the network level.
- The comment text is filterable, so for instance it could be a header like 
```
/**
 * Plugin Name: Blah
 * WDS-Required: True
 */
```
