### PR TITLE
Hooks: Call add_action instead of add_filter

### DIFF
--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -115,8 +115,8 @@ class WDS_Required_Plugins {
 		}
 
 		// Attempt activation + load text domain in the admin.
-		add_filter( 'admin_init', array( $this, 'activate_if_not' ) );
-		add_filter( 'admin_init', array( $this, 'required_text_markup' ) );
+		add_action( 'admin_init', array( $this, 'activate_if_not' ) );
+		add_action( 'admin_init', array( $this, 'required_text_markup' ) );
 		add_filter( 'extra_plugin_headers', array( $this, 'add_required_plugin_header' ) );
 
 		// Filter plugin links to remove deactivate option.


### PR DESCRIPTION
The `admin_init` hook is an action hook, not a filter hook, so for the correct intent, `add_action()` should be called for it instead of `add_filter()`.

At runtime, it doesn't make any difference, but in automated analysis, it does, since a check of the callback can look for the presence of a valid `return` if it's a callback for an `add_filter()`.