### PR TITLE
Fixing open_base_dir- and deprecation-errors.

### DIFF
--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -388,8 +388,9 @@ final class WDS_Required_Plugins {
 	 *
 	 * @return array
 	 */
-	public function filter_plugin_links( $actions = [], $plugin ) {
-
+	public function filter_plugin_links( $actions, $plugin ) {
+		// HOTFIX to prevent ugly and anoying DEPRECATED messages
+		$actions = (array) $actions;
 		// Get our required plugins for network + normal.
 		$required_plugins = array_unique( array_merge( $this->get_required_plugins(), $this->get_network_required_plugins() ) );
 

--- a/wds-required-plugins.php
+++ b/wds-required-plugins.php
@@ -596,20 +596,23 @@ final class WDS_Required_Plugins {
 			return;
 		}
 
+		//
+		$languages_path = dirname( __FILE__, ) . '/languages';
+
 		// Try to load mu-plugin textdomain.
-		if ( load_muplugin_textdomain( 'wds-required-plugins', '/languages/' ) ) {
+		if ( load_muplugin_textdomain( 'wds-required-plugins', str_replace( WPMU_PLUGIN_DIR, '', $languages_path ) ) ) {
 			self::$l10n_done = true;
 			return;
 		}
 
 		// If we didn't load, load as a plugin.
-		if ( load_plugin_textdomain( 'wds-required-plugins', false, '/languages/' ) ) {
+		if ( load_plugin_textdomain( 'wds-required-plugins', false, str_replace( WP_PLUGIN_DIR, '', $languages_path ) ) ) {
 			self::$l10n_done = true;
 			return;
 		}
 
 		// If we didn't load yet, load as a theme.
-		if ( load_theme_textdomain( 'wds-required-plugins', '/languages/' ) ) {
+		if ( load_theme_textdomain( 'wds-required-plugins', $languages_path ) ) {
 			self::$l10n_done = true;
 			return;
 		}


### PR DESCRIPTION
Ola @aubreypwd.

I did some bugfixing and would love to have you review my changes.

The important aspect of this PR are the small fixings for the wrong called *_textdomain functions, which are waiting for 3 different kinds of pathes, so I thought it would make sense to deliver thoose different pathes to reduce noise on the error-logs.

The 2nd commit is just a minor cleanup, to also reduce php8 related warnings on param-order.

Best regards
Carsten